### PR TITLE
Simplify Docker environment set-up for the local deployment of betting-house app

### DIFF
--- a/betting-house/README.md
+++ b/betting-house/README.md
@@ -9,16 +9,9 @@ With the knowledge you have acquired so far, you should be able to improve the a
 
     cd local-deployment
 
-### start DB
+### start docker services
 
     docker compose up
-
-Create tables in DB. When prompt enter password `betting`
-
-    cd ../common-deployment
-    psql -h 127.0.0.1 -d betting  -U betting -f bet-projection.sql
-    psql -h 127.0.0.1 -d betting  -U betting -f akka-persistence.sql
-    psql -h 127.0.0.1 -d betting  -U betting -f akka-projection.sql
 
 ### start the application
 

--- a/betting-house/common-deployment/init_psql.sh
+++ b/betting-house/common-deployment/init_psql.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Copy .sql files to PostgreSQL data directory
+cp /init-scripts/*.sql /docker-entrypoint-initdb.d/
+
+# Start PostgreSQL
+exec gosu postgres /usr/local/bin/docker-entrypoint.sh postgres

--- a/betting-house/common-deployment/init_psql.sh
+++ b/betting-house/common-deployment/init_psql.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+apt-get update && \
+apt-get install -y gosu && \
+rm -rf /var/lib/apt/lists/*
+
 # Copy .sql files to PostgreSQL data directory
 cp /init-scripts/*.sql /docker-entrypoint-initdb.d/
 

--- a/betting-house/local-deployment/docker-compose.yml
+++ b/betting-house/local-deployment/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       POSTGRES_USER: betting
       POSTGRES_PASSWORD: betting
-    entrypoint: /bin/bash -c "apt-get update && apt-get install -y gosu && /init-scripts/init_psql.sh"
+    entrypoint: /init-scripts/init_psql.sh
   zookeeper:
     image: wurstmeister/zookeeper
     ports:

--- a/betting-house/local-deployment/docker-compose.yml
+++ b/betting-house/local-deployment/docker-compose.yml
@@ -2,11 +2,14 @@ version: '2.2'
 services:
   postgres-betting-db:
     image: postgres:latest
+    volumes:
+      - ../common-deployment:/init-scripts
     ports:
       - 5432:5432
     environment:
       POSTGRES_USER: betting
       POSTGRES_PASSWORD: betting
+    entrypoint: /bin/bash -c "apt-get update && apt-get install -y gosu && /init-scripts/init_psql.sh"
   zookeeper:
     image: wurstmeister/zookeeper
     ports:


### PR DESCRIPTION
Git commit message:

```shell
commit 1422c15669ba64e6d09426fbadcda47f5d6f8fa5
Author: Vasile Gorcinschi <vasilegorcinschi@Vasiles-MacBook-Pro.local>
Date:   Fri Sep 22 16:18:31 2023 -0400

    Simplified docker env set-up for local betting-house
    
    In this commit we've removed an extra-step of running SQL
    migration files once Docker postgres container is up. It
    has the advantage of abstracting away this tangental concern
    for people that ramp-up on Akka rather than on Docker.
```